### PR TITLE
Register dmumps_c as an R C-callable in R_init_rmumps

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -3,8 +3,23 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
+/* MUMPS' double-precision C entry point (dmumps_c), compiled into this
+ * package from the bundled MUMPS sources. Declared here only so we can take
+ * its address for R_RegisterCCallable() below; the full prototype, together
+ * with DMUMPS_STRUC_C, lives in dmumps_c.h (shipped in inst/include and made
+ * available to client packages via LinkingTo: rmumps). */
+extern void dmumps_c(void);
+
 void R_init_rmumps(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, NULL, NULL, NULL);
     R_useDynamicSymbols(dll, TRUE);
+    /* Expose dmumps_c to other R packages on every platform via
+     * R_GetCCallable("rmumps", "dmumps_c"). This is required on Windows,
+     * where R_FindSymbol() cannot locate it: a Windows DLL exports only the
+     * symbols it explicitly registers, so an unregistered dmumps_c is
+     * invisible to a dependent package even though it is present in the DLL.
+     * The LinkingTo: rmumps + R_GetCCallable() pattern is used by e.g. the
+     * multbxxc and r2sundials packages. */
+    R_RegisterCCallable("rmumps", "dmumps_c", (DL_FUNC) dmumps_c);
 }


### PR DESCRIPTION
## Summary

This PR registers `dmumps_c` as an R *C-callable* in `R_init_rmumps`, so that
dependent packages can resolve the MUMPS double-precision C entry point with
`R_GetCCallable("rmumps", "dmumps_c")` on **every** platform, including Windows.

It is a two-line addition to `src/init.c` (a forward declaration plus the
registration call). `rmumps`'s own behavior is unchanged.

## Motivation

`rmumps` already supports the `LinkingTo: rmumps` + `R_GetCCallable("rmumps", ...)`
pattern for the `Rmumps__*` wrappers (used by e.g. **multbxxc** and **r2sundials**).
However, the raw `dmumps_c` entry point is currently reachable from another package
only via `R_FindSymbol("dmumps_c", "rmumps")`. That works on Linux/macOS but
**fails on Windows**: a Windows DLL exports only the symbols it explicitly
registers, so an unregistered `dmumps_c` is invisible to a dependent package even
though it is compiled into `rmumps.dll` — `R_FindSymbol` returns `NULL`.

I'm writing an R interface to the
[Uno](https://github.com/cvanaret/Uno) nonlinear solver, for
eventually enabling Discplined Nonlinear Programming in
[CVXR](https://cvxr.rbind.io). Its MUMPS backend calls the raw
`dmumps_c` with its own `DMUMPS_STRUC_C` workspace and reads
`INFOG(12)`/`INFOG(28)` directly off that struct for inertia, so it
needs only the single `dmumps_c` symbol (not the `Rmumps` C++
class). On Linux/macOS the `R_FindSymbol` route works; on Windows it
does not. Registering `dmumps_c` as a C-callable closes that gap for
any package wanting low-level access to the entry point.

## Change

```c
extern void dmumps_c(void);   /* address-only forward declaration */

void R_init_rmumps(DllInfo *dll)
{
    R_registerRoutines(dll, NULL, NULL, NULL, NULL);
    R_useDynamicSymbols(dll, TRUE);
    R_RegisterCCallable("rmumps", "dmumps_c", (DL_FUNC) dmumps_c);
}
```

A forward declaration is used (rather than `#include "dmumps_c.h"`) because
`init.c` is compiled as C while the MUMPS include directory is only on
`PKG_CXXFLAGS`, and there are three Makevars variants
(`Makevars`, `Makevars.omp`, `Makevars.seq`). Taking the function's address needs
no struct definition, so this keeps the change to a single file with no
include-path or Makevars edits. Happy to switch to the header include if you'd
prefer.

## Verification

- `src/init.c` compiles cleanly under the R toolchain with
  `-Wall -Wstrict-prototypes` (no warnings).
- Built and installed the patched package, then resolved the symbol from a small
  test shared object: `R_GetCCallable("rmumps", "dmumps_c")` returns a valid
  pointer with the patch and errors (`function 'dmumps_c' not provided by package
  'rmumps'`) without it.

Thanks for `rmumps` — it saved me so much work because of your effort
on it. I would very much appreciate a quick push to CRAN so that I can
build off it. 
